### PR TITLE
Fix missing remainder bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - fix penalty rule 3
+- fix missing remainder Bits

--- a/classes/qr_code.gd
+++ b/classes/qr_code.gd
@@ -670,3 +670,9 @@ func _set_data(zig_zag_positions: Array) -> void:
 					var position = zig_zag_positions[position_index]
 					modules[position.x][position.y] = ecc_data_list[row][index * 8 + bits]
 					position_index += 1
+	
+	# Add Remainder Bits if necessary.
+	while position_index < zig_zag_positions.size():
+		var position = zig_zag_positions[position_index]
+		modules[position.x][position.y] = false
+		position_index += 1


### PR DESCRIPTION
For some QR versions, the final binary message is not long enough to fill the required number of bits. In this case, it is necessary to add a certain number of 0s to the end of the final message to make it have the correct length.

Fix issue #9 